### PR TITLE
Update motel.json, the list of countries for the brand Super 8

### DIFF
--- a/data/brands/tourism/motel.json
+++ b/data/brands/tourism/motel.json
@@ -1,4 +1,4 @@
-{
+F{
   "properties": {
     "path": "brands/tourism/motel",
     "preserveTags": ["^name"],
@@ -116,7 +116,7 @@
     {
       "displayName": "Super 8",
       "id": "super8-5ddaab",
-      "locationSet": {"include": ["ca", "us"]},
+      "locationSet": {"include": ["ca", "us", "de", "gb", "id", "do"]},
       "matchNames": ["super 8 by wyndham"],
       "tags": {
         "brand": "Super 8",


### PR DESCRIPTION
Updating the list of countries for the Wyndham subbrand according to the brand's official webpage. Adding Germany, United Kingdom, Indonesia and Dominican Republic. More details can be found under the Brand filter with choosing 'Super 8': https://www.wyndhamhotels.com/laquinta/locations)