### PR TITLE
Update car.json for a new brand Vinfast

### DIFF
--- a/data/brands/shop/car.json
+++ b/data/brands/shop/car.json
@@ -1772,6 +1772,20 @@
         "name:zh-Hans": "雷克萨斯",
         "shop": "car"
       }
-    }
+    },
+    {
+   "displayName": "VinFast",
+   "locationSet": {
+       "include": [
+           "vn", "in", "id", "th", "ph", "us", "ca", "fr", "de", "nl", "om", "ae"
+       ]
+   },
+   "tags": {
+       "brand": "VinFast",
+       "brand:wikidata": "Q56660561",
+       "name": "VinFast", 
+       "shop": "car"
+   }
+}
   ]
 }


### PR DESCRIPTION
VinFast is only available in NSI as operator (charging station), not as a brand. Global brand (VinFast continues to expand aggressively in key Asian markets and has global ambitions).

https://vinfast.com/